### PR TITLE
Use threads to log in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Dependencies:
 - oatpp: C++ Api library
 - Googletest: C++ Testing library
 - openssl (optional): Hashing for regression testing. 
+- Curl: For making api requests for Api Testing
 
 Compiler must be compatible with C++23 with `std::views::zip` and `std::expected`
 

--- a/inc/api/structs.hpp
+++ b/inc/api/structs.hpp
@@ -11,7 +11,7 @@ struct JobData {
     std::string status_;
     std::string driverModel_;
     int numCars_;
-    double runtime_;
+    float runtime_;
 };
 
 struct FollowModelParams {

--- a/inc/api/structs.hpp
+++ b/inc/api/structs.hpp
@@ -11,6 +11,7 @@ struct JobData {
     std::string status_;
     std::string driverModel_;
     int numCars_;
+    double runtime_;
 };
 
 struct FollowModelParams {

--- a/inc/sim/comms.hpp
+++ b/inc/sim/comms.hpp
@@ -1,0 +1,73 @@
+/**
+ * @file comms.hpp
+ * @author Ryan Butler
+ * @brief interface for communications manager
+ * @version 0.1
+ * @date 2026-06-07
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+#pragma once
+#include "threadsafeQueue.hpp"
+#include "dataPacket.hpp"
+#include "compression.hpp"
+
+
+// Ends up being a very thin wrapper around the queue. But a good interface for MPI or TCP later...
+class CommunicationsManager
+{
+  private:
+
+    ThreadsafeQueue<DataPacket::ptr>queue_;
+    // Compression algorithm here
+    std::shared_ptr<Compressor> compressor_;
+
+
+    virtual bool trySend(DataPacket::ptr pkt){
+      return queue_.try_push(pkt);
+    }
+
+    virtual void send(DataPacket::ptr pkt){
+      queue_.wait_and_push(pkt);
+    }
+
+    virtual DataPacket::ptr recv(){
+      return *(queue_.wait_and_pop());
+  }
+
+
+  public:
+
+    CommunicationsManager(size_t n, CompressionType t):
+      queue_{n}, compressor_{Compressor::make(t)}{}
+    ~CommunicationsManager() = default;
+
+    template <typename T>
+    bool trySend(std::vector<T>&& data){
+
+      DataPacket::ptr pkt = std::make_shared<CarDataPacket<T>>(std::move(data));
+      pkt->compress(compressor_.get());
+      return trySend(pkt);
+    }
+
+    template <typename T>
+    void send(std::vector<T>&& data){
+        DataPacket::ptr pkt = std::make_shared<CarDataPacket<T>>(std::move(data));
+
+      pkt->compress(compressor_.get());
+      send(pkt);
+    }
+
+    void endOfData(){
+      DataPacket::ptr pkt = std::make_shared<EndOfData>();
+      send(pkt);
+    }
+
+    DataPacket::ptr getPacket(){
+        DataPacket::ptr pkt = *(queue_.wait_and_pop());
+        pkt->decompress(compressor_.get());
+        return pkt;
+    }
+
+};

--- a/inc/sim/compression.hpp
+++ b/inc/sim/compression.hpp
@@ -1,0 +1,86 @@
+/**
+ * @file compression.hpp
+ * @author Ryan Butler
+ * @brief Interface for different data compression schemes (No compression, brotli, zstd)
+ * @version 0.0
+ * @date 2026-06-08
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#pragma once
+#include <vector>
+#include "logStructs.hpp"
+#include <memory>
+
+
+
+enum class CompressionType : uint8_t{
+    UNCOMPRESSED = 0,
+    ZSTANDARD = 1,
+    BROTLI = 2
+};
+
+class Compressor {
+
+
+    // Compression and decompression bytes that each compression type needs to implement
+    virtual size_t compressBytes(std::byte* data, size_t size, std::byte* out) = 0;
+    virtual size_t decompressBytes(std::byte* data, size_t size, std::byte* out) = 0;
+
+    public:
+    Compressor() = default;
+    ~Compressor() = default;
+
+    /**
+     * @brief Compresses the data in input cars based on the implementation of the pure virtual functions
+     * 
+     * @tparam T Type (CarData or CarSnapshots)
+     * @param cars Input vector of data
+     * @param out pointer to pre allocated buffer of the compressed size
+     * @return size_t Actual number of compressed bytes. 
+     */
+    template <typename T> 
+    size_t compress(std::vector<T>&& cars, std::byte* out);
+
+    /**
+     * @brief Decompresses data. 
+     * 
+     * @tparam T Type of data to compress
+     * @param compressed Pointer to compressed bytes
+     * @param csize Number of compressed bytes
+     * @param out Preallocated vector to output the data
+     * @return size_t 
+     */
+    template <typename T>
+    size_t decompress(std::byte* compressed, size_t csize, std::vector<T>& out);
+    
+
+    // Factory constructor
+    static std::shared_ptr<Compressor> make(CompressionType type);
+};
+
+
+// Base no compression case
+struct NoCompression : public Compressor {
+
+    // Pass through reinterpret casts that don't change the size at all 
+    size_t compressBytes(std::byte* data, size_t size, std::byte* out) override;
+    size_t decompressBytes(std::byte* data, size_t size, std::byte* out) override;
+
+};
+
+class ZStandard : public Compressor {
+
+    public:
+    size_t compressBytes(std::byte* data, size_t size, std::byte* out) override;
+    size_t decompressBytes(std::byte* data, size_t size, std::byte* out) override;
+};
+
+class Brotli : public Compressor {
+
+    public:
+    size_t compressBytes(std::byte* data, size_t size, std::byte* out) override;
+    size_t decompressBytes(std::byte* data, size_t size, std::byte* out) override;
+};

--- a/inc/sim/dataPacket.hpp
+++ b/inc/sim/dataPacket.hpp
@@ -1,0 +1,90 @@
+/**
+ * @file dataPacket.hpp
+ * @author Ryan Butler
+ * @brief Data Packet for sending data between the simulation and the logging thread
+ * @version 0.1
+ * @date 2026-06-07
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#pragma once
+
+#include "compression.hpp"
+
+enum class DataType : unsigned char {
+    NO_DATA = 0,
+    END_OF_DATA = 1,
+    SNAPSHOT_DATA = 2,
+    CAR_DATA = 3
+};
+
+
+struct DataPacket {
+
+  
+    using ptr = std::shared_ptr<DataPacket>;
+
+    /**
+     * @brief Compresses the packet. Called before pushing to the queue
+     * 
+     * @param compressor Compressor object to forward to compress. 
+     */
+    virtual void compress(Compressor* compressor) = 0;
+
+    /**
+     * @brief Decompresses the packet. Called after popping from the queue. 
+     * 
+     * @param compressor Compressor object to forward to decompress
+     */
+    virtual void decompress(Compressor* compressor) = 0;
+
+};
+
+template <typename Data_t>
+class CarDataPacket : public DataPacket {
+
+    std::vector<Data_t> cars_;
+    std::vector<std::byte> compressed_;
+    size_t compressedSize_;
+    size_t originalSize_;
+
+    public:
+
+    CarDataPacket() = default;
+    CarDataPacket(std::vector<Data_t>&& cars):cars_{std::move(cars)}{}
+  
+    void compress(Compressor* compressor) override;
+  
+    void decompress(Compressor* compressor) override;
+
+    std::vector<Data_t>&& moveData(){return std::move(cars_);}
+};
+  
+using CarMetadataPacket = CarDataPacket<CarData>;
+using CarSnapshotPacket = CarDataPacket<CarSnapshot>;
+
+struct EndOfData : public DataPacket {
+
+    void compress(Compressor* compressor) override{}
+
+    void decompress(Compressor* compressor) override{}
+};
+
+// Car Data Packet
+template <typename Data_t>
+void CarDataPacket<Data_t>::compress(Compressor* compressor) {
+    // Compressed size may be available via the compression algorithm;
+    compressed_.resize(cars_.size() * sizeof(Data_t));
+    originalSize_ = cars_.size();
+    compressedSize_ = compressor->compress(std::move(cars_), compressed_.data());
+    cars_.clear();
+}
+
+template <typename Data_t>
+void CarDataPacket<Data_t>::decompress(Compressor* compressor){ 
+    cars_.resize(originalSize_);
+    compressor->decompress(compressed_.data(), compressedSize_, cars_);
+    compressed_.clear();
+}

--- a/inc/sim/highway.hpp
+++ b/inc/sim/highway.hpp
@@ -16,7 +16,6 @@
 
 #include "car.hpp"
 #include "flowGenerator.hpp"
-#include "logger.hpp"
 
 struct Highway {
 
@@ -34,7 +33,7 @@ struct Highway {
      * @details Each derived class stores cars differently and has a different conversion algorithm. 
      * @return std::vector<CarSnapshot> 
      */
-    virtual std::vector<CarSnapshot> log(double t) = 0;
+    virtual void log(double t, std::vector<CarSnapshot>& data) = 0;
 
 };
 
@@ -68,7 +67,7 @@ class CpuHighway : public Highway {
 
     CpuHighway(size_t numLanes, std::vector<FlowGenerator> flows, double roadEnd);
     std::expected<std::vector<CarData>, std::string> update(double dt) override;
-    std::vector<CarSnapshot> log(double t) override;
+    void log(double t, std::vector<CarSnapshot>& data) override;
 };
 
 // #ifdef TRAFFIC_WITH_KOKKOS

--- a/inc/sim/logger.hpp
+++ b/inc/sim/logger.hpp
@@ -16,46 +16,52 @@
 #include <iterator>
 #include <ranges>
 #include <filesystem>
+#include <unordered_map>
 #include <expected>
 #include "logStructs.hpp"
 
+// Comms for streaming based logging
+#include "comms.hpp"
 
+
+/**
+ * @brief Car Logger base class. Derived classes handle writing data to a sink (CSV file or sink)
+ * @details contains methods for partitioning cars by the car id to improve disk write speeds. 
+ * Contains many pure virtaul methods
+ * @pure writeSnapshots(snapshots): Write the car snapshots
+ * @pure writeCars(cars): Write Car metadata
+ * @pure logFailure(error): Writes a failure
+ * @pure writeStats(stats): Writes simulation stats
+ * 
+ */
 class CarLogger 
 {
 
-    /// @brief Uncommited logs. Unwritten to file or unwritten to database
-    std::vector<CarSnapshot> logs_;
+    /**
+     * @brief Writes the Car Snapshots to the file or database. Much slower as this hits 
+     * the file system. This is called by the call operator to support streaming. 
+     * 
+     */
+    virtual std::expected<void, std::string> writeSnapshots(std::vector<CarSnapshot> snapshots) = 0; 
 
-    /// @brief Uncommitted logs split up by car id. 
-    std::vector<std::vector<CarSnapshot>> partitions_;
+    /**
+     * @brief Writes Car Metadata to the file/database. 
+     * 
+     * @return std::expected<void, std::string> 
+     */
+    virtual std::expected<void, std::string> writeCars(std::vector<CarData> cardata) = 0;
 
     protected:
-
-    /// @brief Keeps track if partitions is current
-    bool cached = false;
-
-    /// @brief Uncommitted newly made cars (Added in car constructor)
-    std::vector<CarData> cars_;
-
-    void clearLogs();
-
-    /**
-     * @brief Utility for accessing the logs of a specific car. Is expensive unless partition() has been called
-     * 
-     * @param id Car ID to get logs from
-     * @return std::vector<CarLog> vector of logs
-     */
-    std::vector<CarSnapshot> getCar(size_t id);
-
     
     /**
-     * @brief Splits the logs up by which car id. To speed up getCar queries. 
+     * @brief Splits the logs up by which car id and sorted by timestamp. Used to arrange before calling WriteData;
      * 
-     * @param n Number of cars. If not present, then logger needs to compute this 
+     * @param [in] snapshots Car Snapshots sent to the logger 
+     * @param [out] partitions Mapping of car ids to all their timestampe
      */
-    void partition(size_t n = 0);
 
-    std::vector<std::vector<CarSnapshot>>& getPartition();
+
+    void partition(std::vector<CarSnapshot>&& snapshots, std::unordered_map<size_t, std::vector<CarSnapshot>>& partitions);
 
     public:
 
@@ -63,31 +69,12 @@ class CarLogger
     virtual ~CarLogger(){};
 
     /**
-     * @brief Fast Operation for logging a car object. Done at each timestep
+     * @brief Write the simulation stats to the database. Called by the simulation
      * 
-     * @param id Car ID
-     * @param x position
-     * @param v Velocity
-     * @param t timestep
+     * @param s 
+     * @return std::expected<void, std::string> 
      */
-    void log(size_t id, double x, double v, double t); 
-
-    /**
-     * @brief Much slower operation for logging. Called to "commit" the 
-     * logged results to a file or database. Can be left as a default 
-     * for logging that doesn't need to write to files at all
-     * 
-     */
-    virtual std::expected<void, std::string> writeData(){return {};}; 
-
-    virtual std::expected<void, std::string> writeStats(SimulationStats s){return {};};
-
-    /**
-     * @brief Adds information about a specific car. 
-     * 
-     */
-    virtual void addCar(const CarData& carData);
-
+    virtual std::expected<void, std::string> writeStats(SimulationStats s) = 0;
 
     /**
      * @brief Updates the simulation's status to a new status 
@@ -103,11 +90,12 @@ class CarLogger
     virtual std::expected<void, std::string> logFailure(std::string message) = 0;
 
     /**
-     * @brief Adds all the data logs from the highway at a specific timestep to the internal logs
+     * @brief Streaming run function.  Reads data from the comms manager 
+     * and gets it to the appropriate file sink
      * 
-     * @param data 
+     * @param comms Communications manager that has Data Packets coming off the queue. 
      */
-    void fromHighway(std::vector<CarSnapshot> data);
+    void run(CommunicationsManager& comms);
 };
 
 class FileLogger : public CarLogger {
@@ -117,7 +105,9 @@ class FileLogger : public CarLogger {
     FileLogger(std::string basepath);
     ~FileLogger() = default;
 
-    std::expected<void, std::string> writeData() override;
+    std::expected<void, std::string> writeSnapshots(std::vector<CarSnapshot> snapshots) override;
+
+    std::expected<void, std::string> writeCars(std::vector<CarData> data) override;
 
     std::expected<void, std::string> writeStats(SimulationStats s) override;
 
@@ -136,6 +126,8 @@ class DBLogger : public CarLogger {
     std::string jobname_;
     std::string connectionStr_;
     int jobid_;
+    /// @brief Number of unique cars in the simulation
+    size_t nCars_{0};
 
     DBLogger(std::string jobname, std::string config, bool test);
     
@@ -153,8 +145,11 @@ class DBLogger : public CarLogger {
     static std::expected<std::shared_ptr<DBLogger>, std::string> make(std::string jobname, std::string config, std::string followType, bool test);
     ~DBLogger(){};
 
-    // Commits to the database
-    std::expected<void, std::string> writeData() override;
+
+    // Overrides
+    std::expected<void, std::string> writeSnapshots(std::vector<CarSnapshot> snapshots) override;
+
+    std::expected<void, std::string> writeCars(std::vector<CarData> data) override;
 
     std::expected<void, std::string> writeStats(SimulationStats s) override;
 

--- a/inc/sim/simInputs.hpp
+++ b/inc/sim/simInputs.hpp
@@ -19,5 +19,8 @@ struct SimulatorInputs {
     std::shared_ptr<Highway> highway_;
     double totalTime_;
     double dt_;
+
+    // System configuration inputs can live here
+    // As well as compression type
 };
 

--- a/inc/sim/simulator.hpp
+++ b/inc/sim/simulator.hpp
@@ -2,7 +2,7 @@
  * @file simulator.hpp 
  * @author Ryan Butler (rmbutler@outlook.com)
  * @brief Defines the Simulator Class (Interface?)
- * @version 0.2
+ * @version 0.3
  * @date 2025-07-01
  * 
  * @copyright Copyright (c) 2025
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "comms.hpp"
 #include "highway.hpp"
 #include "simInputs.hpp"
 #include <expected>
@@ -23,6 +24,17 @@ private:
     std::shared_ptr<Highway>highway_;
     double totalTime_;
     double dt_;
+
+    // 1 mb of max memory
+    const size_t maxMemory_ = 1024 * 1024;
+    CommunicationsManager comms_;
+
+    // Store for logs. 
+    std::vector<CarSnapshot> snapshots_;
+    std::vector<CarData> cars_;
+    size_t maxSnapshots_;
+    size_t maxCars_;
+
 
     std::expected<void, std::string> mainLoop();
 

--- a/inc/sim/threadsafeQueue-private.hpp
+++ b/inc/sim/threadsafeQueue-private.hpp
@@ -1,0 +1,74 @@
+
+#include "threadsafeQueue.hpp"
+#include <iostream>
+
+template <typename T>
+ThreadsafeQueue<T>::ThreadsafeQueue(size_t n):maxSize{n}{}
+
+template <typename T>
+void ThreadsafeQueue<T>::wait_and_pop(T &value)
+{
+    std::unique_lock<std::mutex> lk(mut);
+    empty_cond.wait(lk,[this]{return !data_queue.empty();});
+    value = std::move(*data_queue.front());
+    data_queue.pop();
+}
+
+template <typename T>
+bool ThreadsafeQueue<T>::try_pop(T &value){
+    std::lock_guard<std::mutex> lk(mut);    
+    if (data_queue.empty())
+        return false;
+    value = std::move(*data_queue.front());
+    data_queue.pop();
+    return true;    
+}
+template <typename T>
+std::shared_ptr<T> ThreadsafeQueue<T>::wait_and_pop(){
+    std::unique_lock<std::mutex> lk(mut);
+    empty_cond.wait(lk,[this]{return !data_queue.empty();});
+    std::shared_ptr<T> res = data_queue.front();
+    data_queue.pop();
+    return res;
+}
+
+template <typename T>
+std::shared_ptr<T> ThreadsafeQueue<T>::try_pop(){
+    std::lock_guard<std::mutex> lk(mut);
+    if(data_queue.empty())
+        return std::shared_ptr<T>();
+    std::shared_ptr<T> res = data_queue.front();
+    data_queue.pop();
+    return res;
+}   
+
+template <typename T>
+bool ThreadsafeQueue<T>::empty() const {
+        std::lock_guard<std::mutex> lk(mut);
+        return data_queue.empty();
+}
+
+template <typename T>
+bool ThreadsafeQueue<T>::try_push(T new_value){
+    std::lock_guard<std::mutex> lk(mut);
+    // Can't push to a full queue
+    if (data_queue.size() == maxSize){
+        return false;
+    }
+    std::shared_ptr<T> data(std::make_shared<T>(std::move(new_value)));
+    data_queue.push(data);
+    // Notify thread waiting on empty queue that data is ready
+    empty_cond.notify_one();
+    return true;
+}
+
+template <typename T>
+void ThreadsafeQueue<T>::wait_and_push(T new_value){
+
+    std::shared_ptr<T> data(std::make_shared<T>(std::move(new_value)));
+    std::unique_lock<std::mutex> lk(mut);
+    full_cond.wait(lk,[this]{return data_queue.size() < maxSize;});
+
+    data_queue.push(data);
+    empty_cond.notify_one();
+}

--- a/inc/sim/threadsafeQueue.hpp
+++ b/inc/sim/threadsafeQueue.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <memory>
+#include <numeric>
+
+template<typename T>
+class ThreadsafeQueue
+{
+private:
+    mutable std::mutex mut;
+    std::queue<std::shared_ptr<T> > data_queue;
+    std::condition_variable empty_cond;
+    std::condition_variable full_cond;
+    size_t maxSize{std::numeric_limits<size_t>::max()};
+public:
+    ThreadsafeQueue() = default;
+
+    ThreadsafeQueue(size_t maxSize);
+
+    void wait_and_pop(T &value); // never use
+
+    bool try_pop(T &value); // never use
+
+    std::shared_ptr<T> wait_and_pop(); // always use
+
+    std::shared_ptr<T> try_pop(); // never use
+
+    bool empty() const;
+
+    bool try_push(T new_value); // use between 80% and 90% capacity
+
+    void wait_and_push(T new_value); // Wait at 90% memory and always push it through
+    
+};
+
+#include "threadsafeQueue-private.hpp"

--- a/inputs/2lane.yml
+++ b/inputs/2lane.yml
@@ -1,6 +1,6 @@
 ---
 # General Information
-jobname: crash-70s
+jobname: 2-lane
 type: "continuous" # differentiates between adding cars upfront or online
 time: 1500
 timestep: 1

--- a/src/api/jobManager.cpp
+++ b/src/api/jobManager.cpp
@@ -30,7 +30,7 @@ void JobManager::threadRoutine(){
         if (j){
             uint32_t id = j->id();
             statuses_[id] = JobStatus::RUNNING;
-            statuses_[id] = j->operator()();
+            statuses_[id] = (*j)();
         } else {
             std::unique_lock lk(queueMutex_);
             cv_.wait(lk, [this](){return !workQueue_.empty() || isDone_.load();});

--- a/src/simulation/CMakeLists.txt
+++ b/src/simulation/CMakeLists.txt
@@ -11,7 +11,6 @@ set (SHARED_SRC
     car.cpp
     flowGenerator.cpp
     highway.cpp
-    logger.cpp
     strategy.cpp)
 
 set (SETUP_SRC
@@ -21,6 +20,8 @@ set (SETUP_SRC
     )
 
 set (SIMULATION_SRC
+    logger.cpp
+    compression.cpp
     simulator.cpp)
 
 find_package(libpqxx CONFIG REQUIRED)
@@ -43,6 +44,5 @@ add_library(pqxx_wrapper INTERFACE)
 target_link_libraries(pqxx_wrapper INTERFACE pqxx_import)
 
 target_link_libraries(setup PUBLIC yaml-cpp::yaml-cpp)
-target_link_libraries(shared PRIVATE pqxx_wrapper)
-target_link_libraries(simulation PUBLIC setup shared initdb)
+target_link_libraries(simulation PUBLIC setup shared initdb pqxx_wrapper)
 

--- a/src/simulation/carFactory.cpp
+++ b/src/simulation/carFactory.cpp
@@ -10,7 +10,6 @@
  */
 #include "sim/carFactory.hpp"
 #include "sim/strategy.hpp"
-#include  "sim/logger.hpp"
 
 #include <memory>
 

--- a/src/simulation/compression.cpp
+++ b/src/simulation/compression.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file Compressor.cpp
+ * @author Ryan Butler
+ * @brief Implements different compression for logging data
+ * @version 0.1
+ * @date 2026-06-08
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#include "sim/compression.hpp"
+
+
+std::shared_ptr<Compressor> Compressor::make(CompressionType type){
+    switch (type)
+    {
+    case CompressionType::UNCOMPRESSED:
+        return std::make_shared<NoCompression>();
+    case CompressionType::ZSTANDARD:
+        return std::make_shared<ZStandard>();
+    case CompressionType::BROTLI:
+        return std::make_shared<Brotli>();
+    default: // No compression if not recognized
+        return std::make_shared<NoCompression>();
+    }
+}
+
+template <typename T>
+size_t Compressor::compress(std::vector<T>&& cars, std::byte* out){
+    std::byte* data = reinterpret_cast<std::byte*>(cars.data());
+    size_t n = cars.size() * sizeof(T);
+    return compressBytes(data, n, out);
+}
+
+template <typename T>
+size_t Compressor::decompress(std::byte* compressed, size_t csize, std::vector<T>& out){
+    std::byte* dataOut = reinterpret_cast<std::byte*>(out.data());
+
+    return decompressBytes(compressed, csize, dataOut);
+}
+
+// Pass through no compression
+size_t NoCompression::compressBytes(std::byte* data, size_t size, std::byte* out){
+    std::copy(data, data + size, out);
+    return size;
+}
+
+size_t NoCompression::decompressBytes(std::byte* data, size_t size, std::byte* out){
+    std::copy(data, data + size, out);
+    return size;
+}
+
+// Z Standard
+size_t ZStandard::compressBytes(std::byte* data, size_t size, std::byte* out){
+    throw std::runtime_error("ZStandard is not implemented yet");
+}
+
+size_t ZStandard::decompressBytes(std::byte* data, size_t size, std::byte* out){
+    throw std::runtime_error("ZStandard is not implemented yet");
+}
+
+// Brotli
+size_t Brotli::compressBytes(std::byte* data, size_t size, std::byte* out){
+    throw std::runtime_error("Brotli compression is not implemented yet");
+}
+
+size_t Brotli::decompressBytes(std::byte* data, size_t size, std::byte* out){
+    throw std::runtime_error("Brotli compression is not implemented yet");
+}
+
+// Template Instantiations
+template size_t Compressor::compress(std::vector<CarData>&& cars, std::byte* out);
+template size_t Compressor::decompress(std::byte* compressed, size_t csize, std::vector<CarData>& out);
+
+template size_t Compressor::compress(std::vector<CarSnapshot>&& cars, std::byte* out);
+template size_t Compressor::decompress(std::byte* compressed, size_t csize, std::vector<CarSnapshot>& out);

--- a/src/simulation/highway.cpp
+++ b/src/simulation/highway.cpp
@@ -152,10 +152,8 @@ std::expected<std::vector<CarData>, std::string> CpuHighway::update(double dt){
             }
             // Map the utility to old lane, new lane
             if (right > left and right > changeThreshold_){
-                // std::println(" R Lane change: Car{} (x = {:.2f}, v = {:.2f}) from lane {} to {}. Utilities: R:{:.3f} L:{:.3f} Stay:{:.3f}", alpha->getId(), alpha->getPosition(), alpha->getVelocity(), ilane, ilane - 1, right, left, changeThreshold_);
                 laneChanges.push_back({alpha ,ilane, ilane-1});
             } else if (left > right and left > changeThreshold_){
-                // std::println(" L Lane change: Car{} (x = {:.2f}, v = {:.2f}) from lane {} to {}. Utilities: R:{:.3f} L:{:.3f} Stay:{:.3f}", alpha->getId(), alpha->getPosition(), alpha->getVelocity(),ilane, ilane + 1, right, left, changeThreshold_);
                 laneChanges.push_back({alpha, ilane, ilane+1});
             }
 

--- a/src/simulation/highway.cpp
+++ b/src/simulation/highway.cpp
@@ -194,26 +194,14 @@ std::expected<std::vector<CarData>, std::string> CpuHighway::update(double dt){
             lanes_[i].insert(*c);
             newCars.push_back({c->data()});
         }
-
     }
     return newCars;
 }
 
-std::vector<CarSnapshot> CpuHighway::log(double t){
-
-    // Calculate number of cars
-    size_t ncars = 0;
-    for (auto ilane : std::views::iota(0UL, nLanes_)){
-        ncars += lanes_[ilane].size();
-    }
-
-    // Allocate data memory up front and collect data. 
-    std::vector<CarSnapshot> data;
-    data.reserve(ncars);
+void CpuHighway::log(double t, std::vector<CarSnapshot>& snapshots){
     for (auto ilane : std::views::iota(0UL, nLanes_)){
         for (auto car : lanes_[ilane]){
-            data.push_back(car.snapshot(t, ilane));
+            snapshots.push_back(car.snapshot(t, ilane));
         }
     }
-    return data;
 }

--- a/src/simulation/logger.cpp
+++ b/src/simulation/logger.cpp
@@ -82,10 +82,7 @@ std::expected<void, std::string> FileLogger::writeSnapshots(std::vector<CarSnaps
         for (const CarSnapshot& c : cars){
             logfile << c.x << "," << c.v << ","<< c.t << "," << c.l<<"\n";
         }
-    }
-
-    for (size_t i = 0; i < n; ++i){
-        
+        logfile.close();
     }
     return {};
 }

--- a/src/simulation/logger.cpp
+++ b/src/simulation/logger.cpp
@@ -24,66 +24,36 @@
 
 namespace fs = std::filesystem;
 
-void CarLogger::log(size_t id, double x, double v, double t) {
-    logs_.push_back({id, x, v, t});
-    cached = false;
-};
 
-void CarLogger::fromHighway(std::vector<CarSnapshot> data){
-    logs_.append_range(data);
-    cached = false;
-}
-
-void CarLogger::addCar(const CarData& cardata){
-    cars_.push_back(cardata);
-}
-
-std::vector<CarSnapshot> CarLogger::getCar(size_t id){
-    if (cached){
-        return partitions_[id];
-    } else {
-        std::vector<CarSnapshot> carSpecific;    
-        auto logs =  std::copy_if(logs_.begin(), logs_.end(), std::back_inserter(carSpecific), [id](CarSnapshot& c){return c.id == id;});
-        return carSpecific;
+void CarLogger::partition(std::vector<CarSnapshot>&& snapshots, std::unordered_map<size_t, std::vector<CarSnapshot>>& partitions){
+    for (CarSnapshot& snapshot : snapshots){
+        size_t id = snapshot.id;
+        if (!partitions.contains(id)){
+            partitions[id] = {};
+        }
+        partitions[id].push_back(std::move(snapshot));
+    }
+    for (auto& [_, logs] : partitions){
+        std::ranges::sort(logs, [](const CarSnapshot& c1, const CarSnapshot& c2){return c1.t < c2.t;});
     }
 }
 
-void CarLogger::clearLogs(){
-    partitions_.clear();
-    logs_.clear();
-    cached = false;
+// Main loop
+void CarLogger::run(CommunicationsManager& comms){
+    DataType messageType = DataType::NO_DATA;
+    while (messageType != DataType::END_OF_DATA){
+        DataPacket::ptr packet = comms.getPacket();
+        if (auto pkt = std::dynamic_pointer_cast<CarMetadataPacket>(packet)){
+            messageType = DataType::CAR_DATA;
+            writeCars(pkt->moveData());
+        } else if (auto pkt = std::dynamic_pointer_cast<CarSnapshotPacket>(packet)){
+            messageType = DataType::SNAPSHOT_DATA;
+            writeSnapshots(pkt->moveData());
+        } else if (auto pkt = std::dynamic_pointer_cast<EndOfData>(packet)){
+            messageType = DataType::END_OF_DATA;
+        }
+    }
 }
-
-std::vector<std::vector<CarSnapshot>>& CarLogger::getPartition(){
-    if (!cached){
-        partition();
-    }
-    return partitions_;
-}
-
-void CarLogger::partition(size_t n) {
-    if (n == 0){
-        auto max = std::ranges::max_element(logs_, [](const CarSnapshot& c1, const CarSnapshot& c2){return c1.id < c2.id;});
-        n = max->id;
-    }
-    // Resize and clear partitions
-    partitions_.resize(n+1);
-    for (auto& v : partitions_){
-        v.clear();
-    }
-
-    // Split all logs by the car.  
-    for (CarSnapshot& c : logs_){
-        partitions_[c.id].push_back(c);
-    }
-
-    // Sort by timestamp
-    for (std::vector<CarSnapshot>& log : partitions_){
-        std::ranges::sort(log, [](const CarSnapshot& c1, const CarSnapshot& c2){return c1.t < c2.t;});
-    }
-    cached = true;
-}
-
 
 // FILE LOGGER
 
@@ -95,12 +65,12 @@ FileLogger::FileLogger(std::string basepath):basepath_{basepath}{
     fs::create_directories(basepath_);
 }
 
-std::expected<void, std::string> FileLogger::writeData(){
+std::expected<void, std::string> FileLogger::writeSnapshots(std::vector<CarSnapshot> snapshots){
 
-    std::vector<std::vector<CarSnapshot>> byCar = getPartition();
+    std::unordered_map<size_t, std::vector<CarSnapshot>> byCar;
+    partition(std::move(snapshots), byCar);
     size_t n = byCar.size();
-
-    for (size_t i = 0; i < n; ++i){
+    for (const auto& [i, cars] : byCar){
         // If file doesn't exist, make it
         fs::path fname = basepath_ / fs::path("car" + std::to_string(i) + ".csv");
         if (!fs::exists(fname)){
@@ -109,11 +79,29 @@ std::expected<void, std::string> FileLogger::writeData(){
         }
         
         std::ofstream logfile(fname, std::ios::app);
-        for (CarSnapshot& c : byCar[i]){
+        for (const CarSnapshot& c : cars){
             logfile << c.x << "," << c.v << ","<< c.t << "," << c.l<<"\n";
         }
     }
-    clearLogs();
+
+    for (size_t i = 0; i < n; ++i){
+        
+    }
+    return {};
+}
+
+std::expected<void, std::string> FileLogger::writeCars(std::vector<CarData> data){
+    fs::path fname = basepath_ / fs::path("car_stats.csv");
+    std::ranges::sort(data, [](const CarData& c1, const CarData& c2){return c1.id < c2.id;});
+    if(!fs::exists(fname)){
+        std::ofstream out(fname);
+        out << "id,a,b,c,p\n";
+    }
+
+    std::ofstream logfile(fname, std::ios::app);
+    for (const CarData& c : data){
+        logfile << c.id << "," << c.a << ","<< c.b << "," << c.c<< "," << c.p <<"\n";
+    }
     return {};
 }
 
@@ -169,30 +157,23 @@ std::expected<std::shared_ptr<DBLogger>, std::string> DBLogger::make(std::string
     return std::shared_ptr<DBLogger>(logger);
 }
 
- std::expected<void, std::string> DBLogger::writeData() {
+ std::expected<void, std::string> DBLogger::writeSnapshots(std::vector<CarSnapshot> snapshots) {
 
-    std::vector<std::vector<CarSnapshot>> byCar = getPartition();
-
-    pqxx::connection connect(connectionStr_);
-
-    if (cars_.empty()){
+    if (snapshots.empty()){
         return std::unexpected("No cars!");
     }
 
-    // Add rows for all the new cars seen. This breaks when splitting up writing into 2 or more steps
-    try {
-        pqxx::work tx(connect);
-        for (CarData& cdata : cars_){
-            tx.exec(std::format("INSERT INTO carData (carid, jobid, follow_a, follow_b, follow_c, politeness)\nVALUES ({}, {}, {}, {}, {}, {})", cdata.id, jobid_, cdata.a, cdata.b, cdata.c, cdata.p));
-        }
-        tx.commit();
-    } catch(const std::exception& e) {
-        return std::unexpected(std::format("Error inserting car info data into database: {}", e.what()));
-    }
-    
+    std::unordered_map<size_t, std::vector<CarSnapshot>> byCar;
+    partition(std::move(snapshots), byCar);
+
+    pqxx::connection connect(connectionStr_);
+
     // Update the big data table
-    for (std::vector<CarSnapshot>& car : byCar){
+    for (auto& [id, car] : byCar){
         if (car.empty()) continue;
+        if (id != car[0].id){
+            return std::unexpected("Partition Mismatch: Car id does not match partition id");
+        }
         try {
             pqxx::work car_transaction(connect);
 
@@ -207,22 +188,38 @@ std::expected<std::shared_ptr<DBLogger>, std::string> DBLogger::make(std::string
         }
     }
 
+
+    return {};
+}
+
+std::expected<void, std::string> DBLogger::writeCars(std::vector<CarData> cars) {
+    pqxx::connection connect(connectionStr_);
+    // Add rows for all the new cars seen. This breaks when splitting up writing into 2 or more steps
+    try {
+        pqxx::work tx(connect);
+        for (CarData& cdata : cars){
+            tx.exec(std::format("INSERT INTO carData (carid, jobid, follow_a, follow_b, follow_c, politeness)\nVALUES ({}, {}, {}, {}, {}, {})", cdata.id, jobid_, cdata.a, cdata.b, cdata.c, cdata.p));
+        }
+        tx.commit();
+    } catch(const std::exception& e) {
+        return std::unexpected(std::format("Error inserting car info data into database: {}", e.what()));
+    }
+
     // Update the number of cars.  This will break if writing to the DB is done in chunks. Number of Unique cars is the number of rows found in car metadata
+    nCars_ += cars.size();
     try {
         pqxx::connection connect(connectionStr_);
         pqxx::work finish_tx(connect);
 
-        std::string updateStatus = std::format("UPDATE ONLY trafficJobs SET numCars = {} WHERE jobid = '{}'", byCar.size(), jobid_);
+        std::string updateStatus = std::format("UPDATE ONLY trafficJobs SET numCars = {} WHERE jobid = '{}'", nCars_, jobid_);
         finish_tx.exec(updateStatus); 
         finish_tx.commit();
         return {};
     } catch(const std::exception& e) {
         return std::unexpected(std::format("Error updating the Number of Cars: {} ", e.what()));
     }
-
-    clearLogs();
-    return {};
 }
+
 
 std::expected<void, std::string> DBLogger::updateStatus(std::string newStatus) {
     try {

--- a/src/simulation/simulator.cpp
+++ b/src/simulation/simulator.cpp
@@ -11,44 +11,73 @@
  */
 #include <iostream>
 #include <vector>
+#include <expected>
+#include <functional>
+#include <memory_resource>
+#include <thread>
 #include "sim/simulator.hpp"
 #include "sim/parser.hpp"
 #include "sim/parserFactory.hpp"
-#include "database/databaseInit.hpp"
-#include <expected>
-#include <functional>
+
 
 Simulator::Simulator(SimulatorInputs input): logger_{input.logger_},
-    highway_{input.highway_}, totalTime_{input.totalTime_}, dt_{input.dt_}{}
+    highway_{input.highway_}, totalTime_{input.totalTime_}, dt_{input.dt_}, comms_{10, CompressionType::UNCOMPRESSED}{
+
+        // Resize vectors to have a maximum memory to stay under the limit 
+        size_t snapshotMem = maxMemory_ * 0.9;
+        size_t carMem = maxMemory_ * 0.1;
+        snapshots_.reserve(snapshotMem);
+        cars_.reserve(carMem);
+        maxSnapshots_ = snapshotMem / sizeof(CarSnapshot);
+        maxCars_ = carMem / sizeof(CarData);
+    }
 
 std::function<std::string(std::string)> Simulator::errorFunc(std::string prefix){
     return [prefix](const std::string& e){return std::format("Error {}: {},", prefix, e);};
 }
 
 std::expected<void, std::string> Simulator::mainLoop(){
+
+    // Logger
+    std::thread loggingThread([this](){logger_->run(comms_);});
     auto start = std::chrono::steady_clock::now();
-    double t = 0;
+    double t = 0.0;
     std::expected <void, std::string> simStatus;
     while (t < totalTime_){
         simStatus = highway_->update(dt_).transform([this](const auto& cdata){
-            for (const auto& car : cdata){ logger_->addCar(car); }
+            for (const auto& car : cdata){cars_.push_back(car);}
         });
         t += dt_;
-        logger_->fromHighway(highway_->log(t));
+        highway_->log(t, snapshots_);
         if (!simStatus.has_value()){
             break;
         }
+
+        // Send to the logger thread
+        if (snapshots_.size() > 0.9 * maxSnapshots_){ // Wait and send at 90%
+            comms_.send(std::move(snapshots_));
+        } else if (snapshots_.size() > 0.8 * maxSnapshots_){ // try to send at 80%
+            if (comms_.trySend(std::move(snapshots_))){
+                snapshots_.clear();
+            }
+        }
+        if (cars_.size() > 0.9 * maxCars_){
+            comms_.send(std::move(cars_));
+        }
     }
 
+    comms_.send(std::move(snapshots_));
+    comms_.send(std::move(cars_));
+    comms_.endOfData();
+
     simStatus = simStatus.transform_error(Simulator::errorFunc("simulating error"));
-    auto logStatus = logger_->writeData().transform_error(Simulator::errorFunc("writing data"));
     auto end = std::chrono::steady_clock::now();
     long ms = std::chrono::duration_cast<std::chrono::microseconds>((end - start)).count();
 
     SimulationStats stats{double(ms / 1000000.0)};
     auto statsStatus = logger_->writeStats(stats).transform_error(Simulator::errorFunc("writing stats"));
 
-    std::string errmsg  = simStatus.error_or("") + logStatus.error_or("") + statsStatus.error_or("");
+    std::string errmsg  = simStatus.error_or("") + statsStatus.error_or("");
     return (errmsg.empty()) ? std::expected<void, std::string>{} : std::unexpected(errmsg);
 }
 

--- a/src/simulation/simulator.cpp
+++ b/src/simulation/simulator.cpp
@@ -29,7 +29,6 @@ Simulator::Simulator(SimulatorInputs input): logger_{input.logger_},
         snapshots_.reserve(snapshotMem);
         cars_.reserve(carMem);
         maxSnapshots_ = snapshotMem / sizeof(CarSnapshot);
-        maxCars_ = carMem / sizeof(CarData);
     }
 
 std::function<std::string(std::string)> Simulator::errorFunc(std::string prefix){
@@ -39,7 +38,7 @@ std::function<std::string(std::string)> Simulator::errorFunc(std::string prefix)
 std::expected<void, std::string> Simulator::mainLoop(){
 
     // Logger
-    std::thread loggingThread([this](){logger_->run(comms_);});
+    std::jthread loggingThread([this](){logger_->run(comms_);});
     auto start = std::chrono::steady_clock::now();
     double t = 0.0;
     std::expected <void, std::string> simStatus;
@@ -53,21 +52,16 @@ std::expected<void, std::string> Simulator::mainLoop(){
             break;
         }
 
-        // Send to the logger thread
-        if (snapshots_.size() > 0.9 * maxSnapshots_){ // Wait and send at 90%
-            comms_.send(std::move(snapshots_));
-        } else if (snapshots_.size() > 0.8 * maxSnapshots_){ // try to send at 80%
-            if (comms_.trySend(std::move(snapshots_))){
-                snapshots_.clear();
-            }
-        }
-        if (cars_.size() > 0.9 * maxCars_){
+        // At 90% memory capacity, send to the logging thread
+        if (snapshots_.size() > 0.9 * maxSnapshots_){
             comms_.send(std::move(cars_));
+            cars_.clear();
+            comms_.send(std::move(snapshots_));
+            snapshots_.clear();
         }
     }
-
-    comms_.send(std::move(snapshots_));
     comms_.send(std::move(cars_));
+    comms_.send(std::move(snapshots_));
     comms_.endOfData();
 
     simStatus = simStatus.transform_error(Simulator::errorFunc("simulating error"));
@@ -76,7 +70,6 @@ std::expected<void, std::string> Simulator::mainLoop(){
 
     SimulationStats stats{double(ms / 1000000.0)};
     auto statsStatus = logger_->writeStats(stats).transform_error(Simulator::errorFunc("writing stats"));
-
     std::string errmsg  = simStatus.error_or("") + statsStatus.error_or("");
     return (errmsg.empty()) ? std::expected<void, std::string>{} : std::unexpected(errmsg);
 }

--- a/tests/algorithmTest.cpp
+++ b/tests/algorithmTest.cpp
@@ -30,6 +30,7 @@ class AlgorithmTest : public ::testing::Test{
         YAML::Node cfg = TestUtil::getConfigNode_3Lane();
         cfg["logtype"] = "test";
         cfg["jobname"] = "Algorithm";
+        cfg["timestep"] = 0.1; // dt = 0.1 tests streaming
 
         // Homogeneous traffic
         cfg["driverParams"]["a_stdev"] = 0.1;

--- a/tests/apiTest.cpp
+++ b/tests/apiTest.cpp
@@ -223,10 +223,8 @@ TEST_F(ApiTest, ValidRequests){
     EXPECT_EQ(response->jsonData["jobname"], "apiTest");
     EXPECT_EQ(response->jsonData["driverModel"], "Gipps");
     EXPECT_EQ(response->jsonData["status"], "DONE");
-    // EXPECT_EQ(response->jsonData["numCars"], 6);
-    std::cout << "Num Cars: " << response->jsonData["numCars"] << std::endl;
-    // std::println("Num Cars: {}", response->jsonData["numCars"]);
-    
+    EXPECT_EQ(response->jsonData["numCars"], 16);
+
 
     response = requester.queryJobs();
     ASSERT_TRUE(response.has_value()) << std::format("Error Querying For Jobs: {}", response.error());

--- a/tests/regression.cpp
+++ b/tests/regression.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <algorithm>
 #include <ranges>
+#include <charconv>
 #include "sim/simulator.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -21,16 +22,17 @@
 
 #include <pqxx/pqxx>
 #include "testUtil.hpp"
+#include <cstring>
 
 #ifdef WITH_OPEN_SSL
     #include <openssl/evp.h>
 #endif
 
-struct XVT{
+struct XVTL{
     double x;
     double v;
     double t;
-    
+    int l;
 };
 
 class RegressionTest : public ::testing::Test {
@@ -72,18 +74,29 @@ protected:
         if (std::filesystem::exists("file-test/logs")) std::filesystem::remove_all("file-test/logs");
     }
 
-    void getXVTFromFIle(std::vector<XVT>& xvts, std::filesystem::path file){
+    void getXVTFromFIle(std::vector<XVTL>& xvts, std::filesystem::path file){
         std::string line;
         std::ifstream in(file);
+        if (!in.good()){
+            std::cout << "Error opening file: " << strerror(errno) << std::endl;
+            FAIL();
+        }
         std::getline(in, line); // eat the first header line
-        std::vector<XVT> snapshots;
         while (std::getline(in, line)){
-            size_t firstComma = std::find(line.begin(), line.end(), ',') - line.begin();
-            size_t secondComma = std::find(line.begin() + firstComma + 1, line.end(), ',') - line.begin();
-            double x = std::stod(line.substr(0, firstComma-1));
-            double v = std::stod(line.substr(firstComma+1, secondComma - firstComma - 1));
-            double t = std::stod(line.substr(secondComma+1));
-            xvts.push_back({x,v,t});
+            std::vector<double> values;
+            for (auto word : std::views::split(line, ',')) {
+                std::string_view token{word};
+                double r = -1;
+                std::from_chars(token.begin(), token.begin() + token.size(), r);
+                values.push_back(r);
+            }
+            if (values.size()  < 4){
+                std::cout << "Not enough values found in file: " << file << " " << values.size() << " Line: " << line << std::endl;
+                FAIL();
+            } else {
+                xvts.push_back({values[0], values[1], values[2], int(values[3])});
+
+            }
         }
     }
 
@@ -134,25 +147,25 @@ TEST_F(RegressionTest, FileDBEquivalence){
     ASSERT_TRUE(Traffic::Simulate("fileConfig.yaml").has_value());
     ASSERT_TRUE(Traffic::Simulate("dbConfig.yaml").has_value());
 
-    // Need to compare both of them, car by car at each timestamp. 
+    // Compare both file and DB, car by car at each timestamp. 
 
     size_t numCars  = std::distance(std::filesystem::directory_iterator("file-test/logs"), std::filesystem::directory_iterator{});
+    numCars -= 2; // Car Stats and Simulation stats files aren't counted. 
     // Read in each file, query the DB for each specific car id. Then check if they are ASSERT_EQ
     pqxx::connection connect("host=localhost port=5432 dbname=trafficDBTest");
     for (size_t carid = 0; carid < numCars; ++carid){
         pqxx::work transaction(connect);
         // Job Id is always 1 because the DB is cleared
-        std::string queryStr = std::format("SELECT x, v, t FROM snapshotData WHERE (carid = {} AND jobid = 1)", carid);
-        std::vector<XVT> dbValues, fileValues;
-        for (auto [x,v,t] : transaction.stream<float, float, float>(queryStr)){
-            dbValues.push_back({x,v,t});
+        std::string queryStr = std::format("SELECT x, v, t, lane FROM snapshotData WHERE (carid = {} AND jobid = 1)", carid);
+        std::vector<XVTL> dbValues, fileValues;
+        for (auto [x,v,t, l] : transaction.stream<float, float, float, int>(queryStr)){
+            dbValues.push_back({x,v,t, l});
         }
-        std::filesystem::path carFile = std::format("file-test/logs/car{}.log", carid);
         
         // File logging:
-        std::filesystem::path p = std::format("file=test/logs/car{}.csv", carid);
+        std::filesystem::path p = std::format("file-test/logs/car{}.csv", carid);
         getXVTFromFIle(fileValues, p);
-        auto compareFunc = [](const XVT& t1, const XVT& t2){return t1.t < t2.t;};
+        auto compareFunc = [](const XVTL& t1, const XVTL& t2){return t1.t < t2.t;};
         std::ranges::sort(dbValues, compareFunc);
         std::ranges::sort(fileValues, compareFunc);
 
@@ -160,6 +173,7 @@ TEST_F(RegressionTest, FileDBEquivalence){
             ASSERT_NEAR(db.x, file.x, 0.01);
             ASSERT_NEAR(db.x, file.x, 0.01);
             ASSERT_NEAR(db.t, file.t, 0.01);
+            ASSERT_EQ(db.l, file.l);
         }
     }
 }
@@ -174,7 +188,7 @@ TEST_F(RegressionTest, FileHashEquivalence){
     }
 
     // Get the hashes for each file and concatenate them
-    size_t numCars  = std::distance(std::filesystem::directory_iterator("file-test/logs"), std::filesystem::directory_iterator{});
+    size_t numCars  = std::distance(std::filesystem::directory_iterator("file-test/logs"), std::filesystem::directory_iterator{}) - 2;
     std::string hashes;
     for (size_t carid = 0; carid < numCars; ++carid){
         std::filesystem::path p = std::format("file-test/logs/car{}.csv", carid);


### PR DESCRIPTION
Use threads to do logging in parallel rather than storing all logs in memory at a time. 