### PR TITLE
Clean up dblogger

### DIFF
--- a/inc/api/DBManager.hpp
+++ b/inc/api/DBManager.hpp
@@ -8,7 +8,6 @@
 
 #include <vector>
 #include <memory>
-#include <pqxx/pqxx>
 #include <expected>
 
 #include "structs.hpp"
@@ -27,8 +26,6 @@ using DBResponse = std::expected<void, std::string>;
 class DBManager {
 
     std::string connectionStr_;
-
-    std::expected<pqxx::connection, std::string> getConnection();
 
 public:
 

--- a/inc/sim/logger.hpp
+++ b/inc/sim/logger.hpp
@@ -131,6 +131,15 @@ class DBLogger : public CarLogger {
 
     DBLogger(std::string jobname, std::string config, bool test);
     
+    /**
+     * @brief Updates the specific field in the jobs table. 
+     * 
+     * @tparam T 
+     * @return std::expected<void, std::string> 
+     */
+    template <typename T>
+    std::expected<void, std::string> updateField(std::string field, T value, std::string errmsg);
+
     public: 
 
     /**

--- a/inc/sim/threadsafeQueue-private.hpp
+++ b/inc/sim/threadsafeQueue-private.hpp
@@ -74,3 +74,9 @@ void ThreadsafeQueue<T>::wait_and_push(T new_value){
     data_queue.push(data);
     empty_cond.notify_one();
 }
+
+template <typename T>
+size_t ThreadsafeQueue<T>::size() const {
+    std::scoped_lock<std::mutex> lk(mut);
+    return data_queue.size();
+}

--- a/inc/sim/threadsafeQueue.hpp
+++ b/inc/sim/threadsafeQueue.hpp
@@ -34,6 +34,7 @@ public:
 
     void wait_and_push(T new_value); // Wait at 90% memory and always push it through
     
+    size_t size() const;
 };
 
 #include "threadsafeQueue-private.hpp"

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -5,11 +5,11 @@ find_package(oatpp 1.3.0 REQUIRED)
 find_package(libpqxx CONFIG REQUIRED)
 
 add_library(api api.cpp)
-target_link_libraries(api PUBLIC oatpp::oatpp pqxx_wrapper PRIVATE dbmanager jobManager initdb)
+target_link_libraries(api PUBLIC oatpp::oatpp PRIVATE pqxx_wrapper dbmanager jobManager initdb)
 
 # Separate dbreader and jobmanager into separate libs for testing
 add_library(dbmanager dbManager.cpp)
-target_link_libraries(dbmanager PUBLIC pqxx_wrapper)
+target_link_libraries(dbmanager PRIVATE pqxx_wrapper)
 
 add_library(jobManager jobManager.cpp)
 target_link_libraries(jobManager PUBLIC shared PRIVATE setup simulation)

--- a/src/api/DBManager.cpp
+++ b/src/api/DBManager.cpp
@@ -12,6 +12,7 @@
 #include "api/DBManager.hpp"
 #include <format>
 #include <iostream>
+#include <pqxx/pqxx>
 #include <unordered_map>
 #include <cstdlib> 
 
@@ -23,15 +24,18 @@ DBManager::DBManager(bool testDB){
     }
 }
 
-std::expected<pqxx::connection, std::string> DBManager::getConnection(){
+namespace {
+
+std::expected<pqxx::connection, std::string> getConnection(std::string connStr){
     try {   
-        return pqxx::connection(connectionStr_);
+        return pqxx::connection(connStr);
     } catch(const std::exception& e) {
         std::cout << "Error connecting to the database" << std::endl;
         std::cerr << e.what() << '\n';
         return std::unexpected(std::format("Error Connecting to the database: {}", e.what()));
     }
 }
+} // anonymous namespace
 
 
 // JOB DATA
@@ -39,7 +43,7 @@ std::expected<pqxx::connection, std::string> DBManager::getConnection(){
 std::expected<JobData, std::string> DBManager::queryJobs(std::string jobname){
     std::string querystr = std::format("SELECT jobname, configfile, status, error, followModel, numCars, runtime FROM TrafficJobs WHERE jobname = '{}'", jobname);
 
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
     pqxx::result result;
@@ -74,7 +78,7 @@ std::expected<JobData, std::string> DBManager::queryJobs(std::string jobname){
 
 std::expected<std::vector<JobData>, std::string> DBManager::queryJobs(){
     std::string querystr = std::format("SELECT jobname, configfile, status, error, followModel, numCars, runtime FROM TrafficJobs");
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
     std::vector<JobData> data;
@@ -92,7 +96,7 @@ std::expected<std::vector<JobData>, std::string> DBManager::queryJobs(){
 // CAR METADATA
 
 std::expected<CarMetadata, std::string>  DBManager::queryCars(std::string jobname, int carid){
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
 
@@ -115,7 +119,7 @@ std::expected<CarMetadata, std::string>  DBManager::queryCars(std::string jobnam
 }
 
 std::expected<std::vector<CarMetadata>, std::string> DBManager::queryCars(std::string jobname){
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
     std::string querystr = std::format("SELECT carid, follow_a, follow_b, follow_c, politeness FROM CarData INNER JOIN TrafficJobs ON TrafficJobs.JobID = CarData.JobID WHERE jobname = '{}'", jobname);
@@ -141,7 +145,7 @@ std::expected<std::vector<CarMetadata>, std::string> DBManager::queryCars(std::s
 
 std::expected<RawData, std::string>  DBManager::queryData(std::string jobname, int carid){
     std::string querystr = std::format("SELECT x, v, t, lane FROM snapshotData INNER JOIN TrafficJobs ON TrafficJobs.JobID = snapshotData.jobid WHERE TrafficJobs.jobname = '{}' and snapshotData.carid = {} ORDER BY snapshotData.t ASC", jobname, carid);
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
     
@@ -168,7 +172,7 @@ std::expected<std::vector<RawData>, std::string> DBManager::queryData(std::strin
 
     std::string querystr = std::format("SELECT carid, x, v, t, lane FROM snapshotData INNER JOIN TrafficJobs ON TrafficJobs.JobID = snapshotData.jobid WHERE TrafficJobs.jobname = '{}' ORDER BY snapshotData.carid ASC, snapshotData.t ASC", jobname);
 
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
 
@@ -196,7 +200,7 @@ std::expected<std::vector<RawData>, std::string> DBManager::queryData(std::strin
 
 std::expected<std::vector<int>, std::string> DBManager::getJobId(std::string jobname) {
     
-    auto connect = getConnection();
+    auto connect = getConnection(connectionStr_);
     if (!connect){return std::unexpected(connect.error());}
     pqxx::work tx{*connect};
     std::vector<int> ids;
@@ -220,7 +224,7 @@ DBResponse DBManager::deleteJob(std::string jobname){
     auto deleteJobByID = [this, &jobname](const std::vector<int>&  jobids) -> DBResponse {
         try {
             for (const int& id : jobids){
-                auto connect = getConnection();
+                auto connect = getConnection(connectionStr_);
                 if (!connect){return std::unexpected(connect.error());}
                 pqxx::work tx{*connect};
                 std::string querystr = std::format("DELETE FROM snapshotData  WHERE jobid = '{}'", id);

--- a/src/simulation/CMakeLists.txt
+++ b/src/simulation/CMakeLists.txt
@@ -44,5 +44,5 @@ add_library(pqxx_wrapper INTERFACE)
 target_link_libraries(pqxx_wrapper INTERFACE pqxx_import)
 
 target_link_libraries(setup PUBLIC yaml-cpp::yaml-cpp)
-target_link_libraries(simulation PUBLIC setup shared initdb pqxx_wrapper)
+target_link_libraries(simulation PUBLIC setup shared PRIVATE initdb pqxx_wrapper)
 

--- a/src/simulation/logger.cpp
+++ b/src/simulation/logger.cpp
@@ -231,24 +231,10 @@ std::expected<void, std::string> DBLogger::writeStats(SimulationStats s) {
 }
 
 std::expected<void, std::string> DBLogger::logFailure(std::string message) {
-
-    return updateStatus("ERROR").and_then([this, &message]() -> std::expected<void, std::string>{
-            try {
-                pqxx::connection connect(connectionStr_);
-                pqxx::work finish_tx(connect);
-        
-                std::string updateMsg = std::format("UPDATE ONLY trafficJobs SET error = '{}' WHERE jobid = '{}'", message, jobid_);
-                finish_tx.exec(updateMsg);
-                finish_tx.commit();
-                return {};
-            } catch(const std::exception& e) {
-                return std::unexpected(std::format("Error updating the error message {} ", e.what()));
-            }
-        });
+    return updateStatus("ERROR").and_then([this, &message](){return updateField("error", message, "error message");});
 }
 
 // Template Instantiations
 template std::expected<void, std::string> DBLogger::updateField(std::string, size_t, std::string);
 template std::expected<void, std::string> DBLogger::updateField(std::string, std::string, std::string);
 template std::expected<void, std::string> DBLogger::updateField(std::string, double, std::string);
-

--- a/src/simulation/logger.cpp
+++ b/src/simulation/logger.cpp
@@ -204,46 +204,30 @@ std::expected<void, std::string> DBLogger::writeCars(std::vector<CarData> cars) 
 
     // Update the number of cars.  This will break if writing to the DB is done in chunks. Number of Unique cars is the number of rows found in car metadata
     nCars_ += cars.size();
+    return updateField("numCars", nCars_, "Number of Cars");
+}
+
+template <typename T>
+std::expected<void, std::string> DBLogger::updateField(std::string key, T value, std::string errMsg){
     try {
         pqxx::connection connect(connectionStr_);
         pqxx::work finish_tx(connect);
 
-        std::string updateStatus = std::format("UPDATE ONLY trafficJobs SET numCars = {} WHERE jobid = '{}'", nCars_, jobid_);
+        std::string updateStatus = std::format("UPDATE ONLY trafficJobs SET {} = '{}' WHERE jobid = '{}'", key, value, jobid_);
         finish_tx.exec(updateStatus); 
         finish_tx.commit();
         return {};
     } catch(const std::exception& e) {
-        return std::unexpected(std::format("Error updating the Number of Cars: {} ", e.what()));
+        return std::unexpected(std::format("Error updating the {}: {} ", errMsg, e.what()));
     }
 }
 
-
 std::expected<void, std::string> DBLogger::updateStatus(std::string newStatus) {
-    try {
-        pqxx::connection connect(connectionStr_);
-        pqxx::work finish_tx(connect);
-
-        std::string updateStatus = std::format("UPDATE ONLY trafficJobs SET status = '{}' WHERE jobid = '{}'", newStatus, jobid_);
-        finish_tx.exec(updateStatus); 
-        finish_tx.commit();
-        return {};
-    } catch(const std::exception& e) {
-        return std::unexpected(std::format("Error updating the Job Status: {} ", e.what()));
-    }
+    return updateField<std::string>("status", newStatus, "Job Status");
 }
 
 std::expected<void, std::string> DBLogger::writeStats(SimulationStats s) {
-    try {
-        pqxx::connection connect(connectionStr_);
-        pqxx::work finish_tx(connect);
-
-        std::string updateStats = std::format("UPDATE ONLY trafficJobs SET runtime = '{}' WHERE jobid = '{}'", s.runtime_, jobid_);
-        finish_tx.exec(updateStats); 
-        finish_tx.commit();
-        return {};
-    } catch(const std::exception& e) {
-        return std::unexpected(std::format("Error updating the simulator status: {} ", e.what()));
-    }
+    return updateField("runtime", s.runtime_, "simulator stats");
 }
 
 std::expected<void, std::string> DBLogger::logFailure(std::string message) {
@@ -261,5 +245,10 @@ std::expected<void, std::string> DBLogger::logFailure(std::string message) {
                 return std::unexpected(std::format("Error updating the error message {} ", e.what()));
             }
         });
-   
 }
+
+// Template Instantiations
+template std::expected<void, std::string> DBLogger::updateField(std::string, size_t, std::string);
+template std::expected<void, std::string> DBLogger::updateField(std::string, std::string, std::string);
+template std::expected<void, std::string> DBLogger::updateField(std::string, double, std::string);
+

--- a/tests/QueueTest.cpp
+++ b/tests/QueueTest.cpp
@@ -6,9 +6,8 @@
 #include <future>
 
 std::vector<int> pop(ThreadsafeQueue<int>& q){
-    std::this_thread::sleep_for(std::chrono::seconds(1));
     std::vector<int> values;
-    while (!q.empty()){
+    while (!q.empty() || values.size() < 10){
         auto integer = q.try_pop();
         if (integer){
             values.push_back(*integer);
@@ -29,6 +28,7 @@ TEST(QueueTest, FullQueue){
     }
 
     std::vector<int> values = f.get();
+    ASSERT_EQ(values.size(), 10);
     for (int i = 0; i < 10; ++i){
         EXPECT_EQ(i, values[i]);
     }


### PR DESCRIPTION
Reduces code duplication in the DB logger and makes the pqxx dependency private for the simulator and the API. Paves the way for abstracting away the database backend