### PR TITLE
Remove interval tree

### DIFF
--- a/inc/sim/laneInfo.hpp
+++ b/inc/sim/laneInfo.hpp
@@ -13,16 +13,16 @@
 #include <expected>
 #include <optional>
 #include <vector>
+#include <set>
 
 /// @brief Lane boundary class to implement IntervalTree's Interval interface
-struct LaneBoundary : public SimpleInterval<double>{
-    size_t position_;
+struct LaneBoundary {
+    double low_;
+    double high_;
 
-    using SimpleInterval<double>::SimpleInterval;
-    LaneBoundary(double low, double high, size_t p):
-        SimpleInterval<double>(low, high), position_{p}{}
-
-    size_t lane() const {return position_;}
+    bool operator==(const LaneBoundary& other) const {
+        return low_ == other.low_ && high_ == other.high_;
+    }
 };    
 
 enum class Direction : int8_t{
@@ -35,9 +35,46 @@ enum class Direction : int8_t{
  * and ends of lanes and segments of lanes. 
  * 
  */
-class LaneInfo {
 
-    IntervalTree<LaneBoundary> iTree_;
+// Replacement for interval tree: 
+// array/vector of sorted sets to prevent looking in interval tree
+
+class LaneInterval {
+
+    std::vector<std::set<double>> lanes_;
+
+    public: 
+
+    // Gets the lane segment (start, end, position) that (x, lane) is in.
+    /**
+     * @brief Get the Lane Segment that x would fall in if it exists. If the lane
+     * doesn't exist, returns std::nullopt. 
+     * 
+     * @param ilane Position of the lane
+     * @param x X position
+     * @return std::optional<LaneBoundary> Returns the low, high and position the x value lands in. 
+     * 
+     * @endif
+     * 
+     */
+    std::optional<LaneBoundary> getLaneSegment(size_t ilane, double x);
+
+    /**
+     * @brief Inserts a lane segment in the correct lane if it can fit there. 
+     * @details checks getLaneSegment() to see if one already exists before adding it. 
+     * 
+     * @param start Start of the lane (meters)
+     * @param end End of the lane (meters)
+     * @param position Lane position (index)
+     * @return true if a lane was added, false if not. 
+     */
+    bool insert(double start, double end, size_t position);
+};
+
+ class LaneInfo {
+
+    LaneInterval lanes_;
+
     std::vector<std::optional<double>> laneEnds_;
     double endOfRoad_ = 0;
     

--- a/src/simulation/laneInfo.cpp
+++ b/src/simulation/laneInfo.cpp
@@ -1,21 +1,77 @@
 #include "sim/laneInfo.hpp"
 #include <ranges>
 #include <algorithm>
+#include <array>
 #include <format>
+#include <algorithm>
 #include <ranges>
 #include <functional>
 #include <iterator>
+
+std::optional<LaneBoundary> LaneInterval::getLaneSegment(size_t ilane, double x){
+    if (ilane >= lanes_.size()){
+        return std::nullopt;
+    } 
+    const std::set<double>& lane = lanes_[ilane];
+
+    if (x < *lane.begin() || x > *lane.rbegin()){
+        return std::nullopt;
+    }
+    // Get the index
+    auto iter = std::lower_bound(lane.begin(), lane.end(), x);
+    // On a boundary. Always in the segment. Which segment? If index is even, then (iter, iter+1), otherwise, iter-1, iter
+    if (*iter == x){
+        if (std::distance(lane.begin(), iter) % 2 == 1){
+            --iter;
+        }
+        return LaneBoundary(*iter, *(++iter));
+    }
+    // Not on a boundary. Lower_bound will always give me the upper bound of the interval
+    if (std::distance(lane.begin(), iter) % 2 == 1){
+        --iter;
+        return LaneBoundary(*iter, *(++iter));
+    } else {
+        return std::nullopt;
+    }
+
+}
+// what if it was just a set if numbers? If the index we find is odd or even it is in a lane ir not
+// 0, 20, 55,60, 85,100 -> 30,40 lower_bound is the same for both AND lower bound is at an odd index
+
+bool LaneInterval::insert(double start, double end, size_t position){
+    if (position >= lanes_.size()){
+        lanes_.resize(position + 1);
+        lanes_[position] = {start, end};
+        return true;
+    } else if (lanes_[position].empty()){
+        lanes_[position] = {start, end};
+        return true;
+    } else {
+        const std::set<double>& lane = lanes_[position];
+        auto lower = std::lower_bound(lane.begin(), lane.end(), start);
+        auto higher = std::lower_bound(lane.begin(), lane.end(), end);
+        // auto diff = std::distance(lane.begin(), lower);
+        if (lower == higher && lower != lane.end()){
+            auto dist = std::distance(lane.begin(), lower);
+            if (dist % 2 == 1){
+                lanes_[position].insert_range(std::array{start, end});
+            }
+            return dist % 2 == 1;
+        } else if (lower == lane.end()) {
+            lanes_[position].insert_range(std::array{start, end});
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
 
 LaneInfo::LaneInfo(double bias, double changePressure, double switchThreshold):
     bias_{bias}, changePressure_{changePressure}, switchThreshold_{switchThreshold}{}
 
 
 bool LaneInfo::addSegment(double start, double end, size_t position){
-
-    std::vector<LaneBoundary> overlaps = iTree_.findOverlaps(LaneBoundary{start, end});
-    auto iter = std::ranges::find_if(overlaps, [position](const LaneBoundary& l){return l.position_ == position;});
-    if (iter == overlaps.end()){
-        iTree_.insert({start, end, position});
+    if (lanes_.insert(start, end, position)){
 
         // Insert into the laneEnds lookup table
         if (laneEnds_.size() < position+1){
@@ -29,18 +85,14 @@ bool LaneInfo::addSegment(double start, double end, size_t position){
                                                             { return std::max(cur, end); })
                                                  .or_else([end]()
                                                             { return std::make_optional(end); });
+        return true;
+    } else {
+        return false;
     }
-    return iter == overlaps.end();
 }
 
 std::optional<LaneBoundary> LaneInfo::getLane(double x, size_t ilane){
-    std::vector<LaneBoundary> overlaps = iTree_.findOverlaps(x);
-    auto iter = std::ranges::find_if(overlaps, [ilane](const LaneBoundary& l){return l.position_ == ilane;});
-    if (iter != overlaps.end()){
-        return std::make_optional(*iter);
-    } else {
-        return std::nullopt;
-    }
+    return lanes_.getLaneSegment(ilane, x);
 }
 
 bool LaneInfo::laneValid(double x, size_t ilane){
@@ -53,7 +105,7 @@ std::expected<double, std::string> LaneInfo::endOfSegment(double x, size_t ilane
     //                         .or_else([x, ilane](){return std::unexpected(std::format("Lane {} is not present at x = {}", ilane, x));});
     std::optional<LaneBoundary> end = getLane(x, ilane);
     if (end){
-        return end->high();
+        return end->high_;
     } else {
         return std::unexpected(std::format("Lane {} is not present at x = {}", ilane, x));
     }

--- a/tests/laneInfoTest.cpp
+++ b/tests/laneInfoTest.cpp
@@ -1,6 +1,77 @@
 #include "sim/laneInfo.hpp"
 #include <gtest/gtest.h>
 #include <ranges>
+#include <algorithm>
+
+class LaneIntervalHolderTest : public ::testing::Test {
+    protected:
+    LaneInterval lanes_;
+
+    void SetUp(){
+        ASSERT_TRUE(lanes_.insert(0, 20, 0));
+        ASSERT_TRUE(lanes_.insert(50, 80, 0));
+        ASSERT_TRUE(lanes_.insert(0, 55, 1));
+        ASSERT_TRUE(lanes_.insert(75, 100, 1));
+        ASSERT_TRUE(lanes_.insert(0, 55, 2));
+        ASSERT_TRUE(lanes_.insert(80, 100, 2));
+    }
+
+};
+
+TEST_F(LaneIntervalHolderTest, getSegment){
+    std::optional<LaneBoundary> result;
+
+    result = lanes_.getLaneSegment(0, 15);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), LaneBoundary(0, 20));
+
+    result = lanes_.getLaneSegment(0, 20);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(0, 20));
+
+    result = lanes_.getLaneSegment(0, 55);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(50, 80));
+
+    result = lanes_.getLaneSegment(1, 0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(0, 55));
+
+    result = lanes_.getLaneSegment(1, 40);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(0, 55));
+
+    result = lanes_.getLaneSegment(1, 75);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(75, 100));
+
+    result = lanes_.getLaneSegment(1, 80);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(75, 100));
+
+    result = lanes_.getLaneSegment(2, 40);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(0, 55));
+
+    result = lanes_.getLaneSegment(2, 80);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(80, 100));
+
+    result = lanes_.getLaneSegment(2, 100);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result, LaneBoundary(80, 100));
+}
+
+TEST_F(LaneIntervalHolderTest, nonSegments){
+    EXPECT_FALSE(lanes_.getLaneSegment(0, 35).has_value());
+    EXPECT_FALSE(lanes_.getLaneSegment(0, -15).has_value());
+    EXPECT_FALSE(lanes_.getLaneSegment(0, 120).has_value());
+    EXPECT_FALSE(lanes_.getLaneSegment(3, 20).has_value());
+    EXPECT_FALSE(lanes_.getLaneSegment(2, 60).has_value());
+
+}
+
+
 
 class LaneInfoTest : public ::testing::Test {
     protected:


### PR DESCRIPTION
Removes the interval tree and replaces it with a sorted set instead. Some profiling found that this drastically improves runtime. 